### PR TITLE
Fix Produce.apply() MalformedInputExceptions

### DIFF
--- a/library/src/main/scala/produce.scala
+++ b/library/src/main/scala/produce.scala
@@ -1,32 +1,51 @@
 package pamflet
 
-import java.io.{File,FileOutputStream}
+import java.io.{File,FileOutputStream,InputStreamReader,OutputStream,Reader,
+                StringReader}
+
+import scala.annotation.tailrec
 
 object Produce {
   def apply(contents: Contents, target: File) {
-    def write(path: String, contents: String) {
+    def writeString(path: String, contents: String) {
+      write(path, new StringReader(contents))
+    }
+    def write(path: String, r: Reader) {
       val file = new File(target, path)
       new File(file.getParent).mkdirs()
-      val out = new FileOutputStream(file)
-      out.write(contents.getBytes("utf-8"))
-      out.close()
+      val os = new FileOutputStream(file)
+      copy(r, os)
+      r.close()
+      os.close()
+    }
+    def copy(r: Reader, os: OutputStream) {
+      @tailrec def doCopy: Unit = {
+        val byte = r.read()
+        if (byte != -1) {
+          os.write(byte)
+          doCopy
+        }
+      }
+      doCopy
+      os.flush()
     }
     val manifest = "pamflet.manifest"
     val printer = Printer(contents, Some(manifest))
     contents.pages.foreach { page =>
-      write(Printer.fileify(page.name), printer.print(page).toString)
+      writeString(Printer.fileify(page.name), printer.print(page).toString)
     }
     val css = contents.css.map { case (nm, v) => ("css/" + nm, v) }.toList
     css.foreach { case (path, contents) =>
-      write(path, contents)
+      writeString(path, contents)
     }
     val paths = filePaths(contents)
     paths.foreach { path =>
-      write(path, scala.io.Source.fromInputStream(
+      write(path, new InputStreamReader(
         new java.net.URL(Shared.resources, path).openStream()
-      ).mkString(""))
+      ))
+println("*** ... written.")
     }
-    write(manifest, (
+    writeString(manifest, (
       "CACHE MANIFEST" ::
       css.map { case (n,_) => n } :::
       contents.pages.map { p => Printer.webify(p.name) } :::


### PR DESCRIPTION
Pamflet library's `Produce.apply()` no longer assumes a UTF-8 encoding on resources it's copying from the jar to the statically generated pamflet. That assumption was causing MalformedInputExceptions on my 64-bit Ubuntu
system (with OpenJDK).
