### PR TITLE
Fix to Produce.apply()

### DIFF
--- a/library/src/main/scala/produce.scala
+++ b/library/src/main/scala/produce.scala
@@ -43,7 +43,6 @@ object Produce {
       write(path, new InputStreamReader(
         new java.net.URL(Shared.resources, path).openStream()
       ))
-println("*** ... written.")
     }
     writeString(manifest, (
       "CACHE MANIFEST" ::


### PR DESCRIPTION
Pamflet library's `Produce.apply()` no longer assumes a UTF-8 encoding on
resources it's copying from the jar to the statically generated pamflet.
That assumption was causing MalformedInputExceptions on my 64-bit Ubuntu
system (with OpenJDK).

Be sure you get both commits. I didn't rebase.
