### PR TITLE
Add pamflet.arrow configuration option for next page icon.

### DIFF
--- a/docs/template.properties
+++ b/docs/template.properties
@@ -2,3 +2,4 @@ version=0.4.0
 vrsn=040
 scala=2.9.1
 github=n8han/pamflet
+pamflet.arrow=>

--- a/library/src/main/scala/printer.scala
+++ b/library/src/main/scala/printer.scala
@@ -93,7 +93,9 @@ case class Printer(contents: Contents, manifest: Option[String]) {
       }
     val (prev, next) = lastnext(contents.pages, None)
     val bigScreen = "screen and (min-device-width: 800px), projection"
-    
+   
+    val arrow = page.template.get("pamflet.arrow") getOrElse "❧"
+
     val html = <html>
       <head>
         <title>{ "%s — %s".format(contents.title, page.name) }</title>
@@ -138,13 +140,13 @@ case class Printer(contents: Contents, manifest: Option[String]) {
         { prev.map { p =>
           <a class="page prev nav" href={ Printer.webify(p)}>
             <span class="space">&nbsp;</span>
-            <span class="flip">❧</span>
+            <span class="flip">{arrow}</span>
           </a>
         }.toSeq ++
         next.map { n =>
           <a class="page next nav" href={ Printer.webify(n)}>
             <span class="space">&nbsp;</span>
-            <span>❧</span>
+            <span>{arrow}</span>
           </a>
         }.toSeq }
         <div class="container">


### PR DESCRIPTION
This commit adds a new template.properties configuration option
"pamflet.arrow" which allows the user to set the string used for
the next page icon.  The string (e.g. ">") is used as the next page
icon on the right side of the page and is flipped horizontally to create
the previous page icon (e.g. "<").

If no configuration option is given, the previously used character is used as the default.
