### PR TITLE
Fix for: Black box when hovering left arrow in IE9.

### DIFF
--- a/library/src/main/resources/webroot/css/pamflet-grid.css
+++ b/library/src/main/resources/webroot/css/pamflet-grid.css
@@ -43,8 +43,6 @@ span.flip {
     -webkit-transform: rotate(180deg);  
     -ms-transform: rotate(180deg);  
     transform: rotate(180deg);  
-    filter: progid:DXImageTransform.Microsoft.Matrix( 
-        M11=-1, M12=-1.2246063538223773e-16, M21=1.2246063538223773e-16, M22=-1, sizingMethod='auto expand');
     zoom: 1;
 }
 


### PR DESCRIPTION
I discovered that in IE9, when hovering the left arrow for prev/next page navigation, the element turns black. I made a fix in our custom.css, but it would be better if I could help out upstream. 

I've tested it in IE8, IE9, FF and Chrome. Of course, I may have misunderstood why the filter-css-property was there in the first place. 
