### PR TITLE
don't close img tag for html5

### DIFF
--- a/knockoff/src/main/scala/imgs.scala
+++ b/knockoff/src/main/scala/imgs.scala
@@ -1,0 +1,12 @@
+package pamflet
+
+import scala.xml.Node
+import com.tristanhunt.knockoff._
+
+// see http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements
+trait Html5Imgs extends Discounter { self: XHTMLWriter =>
+  override def imageLinkToXHTML : ( Seq[Span], String, Option[String] ) => Node = {
+    ( spans, url, title ) => <img src={ url } title={ title.getOrElse(null) }
+                                  alt={ spans.map( spanToXHTML(_) ) } />
+  }
+}

--- a/knockoff/src/main/scala/parsers.scala
+++ b/knockoff/src/main/scala/parsers.scala
@@ -8,3 +8,4 @@ object PamfletDiscounter
   with FencedDiscounter
   with SmartyDiscounter
   with IdentifiedHeaders
+  with Html5Imgs


### PR DESCRIPTION
knockoff emits XHTML, but in HTML5 `img` is a [void element](http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements).

(I first thought this was causing some previewing issue when looking at "Additional resources" page in Pamflet's pamflet, but it seems to be more to do with svg than img tag since I was able to display png fine.)
