### PR TITLE
exclude FencedChunk from link conversion (fixes None.get)

### DIFF
--- a/knockoff/src/main/scala/fenced.scala
+++ b/knockoff/src/main/scala/fenced.scala
@@ -19,12 +19,11 @@ trait FencedDiscounter extends Discounter {
 
 trait FencedChunkParser extends ChunkParser {
   override def chunk : Parser[ Chunk ] = {
-    horizontalRule | leadingStrongTextBlock | leadingEmTextBlock | 
-    bulletItem | numberedItem | indentedChunk | header | blockquote | 
-    linkDefinition | fencedChunk | textBlockWithBreak | textBlock | 
-    emptyLines
+    horizontalRule | leadingStrongTextBlock | leadingEmTextBlock | bulletItem |
+    numberedItem | indentedChunk | header | blockquote | linkDefinition |
+    htmlBlock | fencedChunk | textBlockWithBreak | textBlock | emptyLines | emptySpace
   }
-
+  
   def fencedChunk : Parser[ Chunk ] =
     fence ~> opt(brush) ~ emptyLine ~
       rep1(unquotedTextLine | emptyLine) <~ fence <~ emptyLine ^^ {

--- a/knockoff/src/main/scala/smarty.scala
+++ b/knockoff/src/main/scala/smarty.scala
@@ -11,6 +11,14 @@ trait SmartyDiscounter extends Discounter {
 }
 
 trait SmartySpanConverter extends SpanConverter {
+  override def apply( chunk : Chunk ) : Seq[Span] = {
+    chunk match {
+      case IndentedChunk(content)  => List( new Text(content) )
+      case FencedChunk(content, _) => List( new Text(content) )
+      case _ => convert( chunk.content, Nil )
+    }
+  }
+
   val punctClass = """[!\"#\$\%'()*+,-.\/:;<=>?\@\[\\\]\^_`{|}~]"""
   val closeClass = """[^\ \t\r\n\[\{\(\-]"""
   def smartyMatchers : List[ String => Option[SpanMatch] ] = List(

--- a/library/src/main/scala/storage.scala
+++ b/library/src/main/scala/storage.scala
@@ -61,7 +61,13 @@ case class FileStorage(base: File) extends Storage {
   def knock(file: File, propFiles: Seq[File]): (Seq[Block], Template) = { 
     val frontin = Frontin(read(file))
     val template = StringTemplate(propFiles, frontin header)
-    PamfletDiscounter.knockoff(template(frontin body)) -> template
+    try {
+      PamfletDiscounter.knockoff(template(frontin body)) -> template
+    } catch {
+      case e: Throwable =>
+        Console.err.println("Error while processing " + file.toString)
+        throw e
+    }
   }
   def isMarkdown(f: File) = (
     !f.isDirectory &&


### PR DESCRIPTION
related tristanjuricek/knockoff#36
## steps

create a page with the following content:

``````
## foo

```scala
val turtlePosition = Lens.lensu[Turtle, Point] (
  (a, value) => a.copy(position = value),
  _.position)
val pointX = Lens.lensu[Point, Double] (
  (a, value) => a.copy(x = value),
  _.x)
```
``````
## problem

```
HTTP ERROR: 500

Problem accessing /foo.html. Reason:

    None.get
```
## notes

This was likely introduced when I upgraded knockoff to 0.8.1.
There's a conversion process which tries to resolve link formats, and by default only `IndentedChunk` is excluded from it. I just added `FencedChunk` to the exclusion, and that seemed to solve the issue for this case.

If someone had malformed link in non-code text, she could still hit `None.get`.
