### PR TITLE
mobile css touchups

### DIFF
--- a/library/src/main/resources/webroot/css/pamflet-grid.css
+++ b/library/src/main/resources/webroot/css/pamflet-grid.css
@@ -59,11 +59,6 @@ a.tochead {
     color: #06c;
     background: #efefef;
 }
-a.header-link {
-    color: inherit;
-    text-decoration: none;
-    margin-left: 0.1em;
-}
 a.header-link:hover {
     color: #06c;
     background: #efefef;
@@ -78,18 +73,15 @@ h5:hover span.header-link-content:before {
     font-size: 0.75em;
     vertical-align: top;
 }
-div.language-bar ul {
+ul.language-bar {
+    display: inline;
     float: right;
     list-style: none;
-    margin: 0.1em;
+    margin: 0.0em 0.5em 0.0em 0.5em;
 }
-div.language-bar ul li {
-    display: block;
-    float: left;
-    margin-left: 12px;
-}
-div.lang-item {
-    float: left;
+ul.language-bar li {
+    display: inline;
+    margin-left: 1em;
 }
 div.highlight-outer {
     display: block;

--- a/library/src/main/resources/webroot/css/pamflet.css
+++ b/library/src/main/resources/webroot/css/pamflet.css
@@ -29,14 +29,6 @@ div.bottom.nav {
     margin-bottom: 1em;
     padding-bottom: 1em;
 }
-div.bottom.nav div.nextpage {
-    float: left;
-    margin: 0px;
-}
-div.bottom.nav div.language-bar {
-    float: left;
-    margin: 0px;
-}
 div.bottom.nav.end {
     padding-bottom: 0;
 }
@@ -71,6 +63,14 @@ a.page {
     display: none;
 }
 a.fork {
+    display: none;
+}
+a.header-link {
+    color: inherit;
+    text-decoration: none;
+    margin-left: 0.1em;
+}
+ul.language-bar {
     display: none;
 }
 div.highlight-outer {

--- a/library/src/main/scala/printer.scala
+++ b/library/src/main/scala/printer.scala
@@ -115,8 +115,7 @@ case class Printer(contents: Contents, globalized: Globalized, manifest: Option[
         page.template.get("lang-" + langCode) getOrElse {
           Language.languageName(langCode) getOrElse langCode
         }
-      <div class="span-6 language-bar">
-        <ul>
+      <ul class="language-bar">
         {
           val lis = 
             for {
@@ -126,8 +125,7 @@ case class Printer(contents: Contents, globalized: Globalized, manifest: Option[
           if (lis.size < 2) Nil
           else lis
         }
-        </ul>
-      </div>
+      </ul>
     }
 
   def print(page: Page) = {
@@ -246,20 +244,15 @@ case class Printer(contents: Contents, globalized: Globalized, manifest: Option[
                 case page: ContentPage =>
                   toXHTML(page.blocks) ++ next.collect {
                     case n: AuthoredPage =>
-                      <div class="bottom nav">
-                        <div class="span-10 nextpage">
-                          <em>Next Page</em>
-                          <span class="arrow">{arrow}</span>
-                          <a href={Printer.webify(n)}> {n.name} </a>
-                        </div>
+                      <div class="bottom nav span-16">
+                        <em>Next Page</em>
+                        <span class="arrow">{arrow}</span>
+                        <a href={Printer.webify(n)}> {n.name} </a>                        
                         { languageBar(page) }
-                        <br/>
                       </div>
                     case _ =>
-                      <div class="bottom nav end">
-                        <div class="span-10 nextpage">&nbsp;</div>
+                      <div class="bottom nav end span-16">
                         { languageBar(page) }
-                        <br/>
                       </div>
                   } ++ toc(page) ++ comment(page)
                 case page: ScrollPage =>


### PR DESCRIPTION
- hide the tiny underline for invisible `a.header-link` on mobile
- hide the language bar on mobile
