### PR TITLE
fixes line ending squashing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val common = ls.Plugin.lsSettings ++ Seq(
   organization := "net.databinder",
-  version := "0.5.0",
+  version := "0.5.1-SNAPSHOT",
   scalaVersion := "2.10.3",
   crossScalaVersions := Seq("2.10.3"),
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),

--- a/library/src/main/scala/storage.scala
+++ b/library/src/main/scala/storage.scala
@@ -58,7 +58,7 @@ case class FileStorage(base: File) extends Storage {
     }.toSeq
   }
   def read(file: File) = doWith(scala.io.Source.fromFile(file)) { source =>
-    source.getLines().mkString("")
+    source.mkString("")
   }
   def knock(file: File, propFiles: Seq[File]): (Seq[Block], Template) = {
     val frontin = Frontin(read(file))


### PR DESCRIPTION
## steps

00.md:

```
Someone said:

> This is good.
```
## problem

Currently it renders:

Someone said: > This is good.
## what this changes

It's rendered:

Someone said:

> This is good.
## notes

This was introduced in 288e78ab1f2dd4535f94cbaa5216311f8cc29383.
I'm changing `source.getLines().mkString("")` back to `source.mkString("")`.

/cc @grahamar
