### PR TITLE
sbt is using pamflet

### DIFF
--- a/docs/99.markdown
+++ b/docs/99.markdown
@@ -11,5 +11,6 @@ Who's Using Pamflet?
 * [BND book](http://bnd-book.duck-asteroid.cloudbees.net/BND.html)
 * [learning Scalaz](http://eed3si9n.com/learning-scalaz/)
 * [tetrix in Scala](http://eed3si9n.com/tetrix-in-scala/)
+* [sbt](http://www.scala-sbt.org/0.13/tutorial/index.html)
 
 Are you using Pamflet? Add your project and send a pull request.


### PR DESCRIPTION
We are live with two pamflets on current sbt site:
- http://www.scala-sbt.org/0.13/tutorial/index.html
- http://www.scala-sbt.org/0.13/docs/index.html
