### PR TITLE
Drop credentials

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,6 @@ lazy val common = Seq(
       case _ => Nil
     }
   },
-  credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
   homepage :=
     Some(new java.net.URL("http://www.foundweekends.org/pamflet/")),
   licenses := Seq("LGPL v3" -> url("http://www.gnu.org/licenses/lgpl.txt")),


### PR DESCRIPTION
Added way back in
https://github.com/foundweekends/pamflet/commit/3152f9aba5c61e79cae4da4cacc4fd7bc9ba579b,
is it still required these days?

It produces 4x "Credentials file /Users/dnw/.ivy2/.credentials does not
exist" warnings (one per project).