### PR TITLE
use SFMono + undo pink

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val unusedWarnings = Seq(
   "-Ywarn-unused"
 )
 
-val Scala212 = "2.12.8"
+val Scala212 = "2.12.10"
 
 lazy val updateLaunchconfig = TaskKey[File]("updateLaunchconfig")
 

--- a/library/src/main/resources/webroot/css/color_scheme-github.css
+++ b/library/src/main/resources/webroot/css/color_scheme-github.css
@@ -1,7 +1,7 @@
 body.color_scheme-github pre,
 body.color_scheme-github code,
 body.color_scheme-github tt {
-    font-family: Consolas, 'Liberation Mono', Courier, monospace;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Courier, monospace;
 }
 body.color_scheme-github pre {
     font-size: 80%

--- a/library/src/main/resources/webroot/css/color_scheme-monokai.css
+++ b/library/src/main/resources/webroot/css/color_scheme-monokai.css
@@ -1,7 +1,8 @@
 body.color_scheme-monokai pre,
 body.color_scheme-monokai code,
 body.color_scheme-monokai tt {
-    font-family: Consolas, 'Liberation Mono', Courier, monospace;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Courier, monospace;
+    color: #f8f8f2;
 }
 body.color_scheme-monokai pre {
     font-size: 80%

--- a/library/src/main/resources/webroot/css/pamflet-grid.css
+++ b/library/src/main/resources/webroot/css/pamflet-grid.css
@@ -11,7 +11,13 @@ body {
     /* font-family: "Warnock Pro", "Goudy Old Style", "Palatino", "Book Antiqua", Georgia, serif; */
 }
 pre, code, tt {
-    font-family: 'andale mono', 'lucida console', monospace
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Courier, monospace;
+    color: black;
+}
+p > code, p > tt {
+    background-color: rgba(30,30,30,.05);
+    border-radius: 3px;
+    padding: .2em .4em;
 }
 div.top.nav {
     z-index: 1;


### PR DESCRIPTION
This uses SFMono as the monospace font, and also it undoes the pink color that came in with switching to Bootstrap in https://github.com/foundweekends/pamflet/pull/108/commits/14e5d8eabeddbcc967d3f1b12adcc0f25ad4ecb2.

## before

<img width="525" alt="mono-before" src="https://user-images.githubusercontent.com/184683/64752671-6434d600-d4ee-11e9-8057-4b67014835ac.png">
<img width="572" alt="mono-before2" src="https://user-images.githubusercontent.com/184683/64752673-6860f380-d4ee-11e9-87f7-890e82fc815c.png">

## after

<img width="518" alt="mono-after" src="https://user-images.githubusercontent.com/184683/64752686-731b8880-d4ee-11e9-9f1e-9ff232114839.png">
<img width="541" alt="mono-after2" src="https://user-images.githubusercontent.com/184683/64752689-76167900-d4ee-11e9-84b5-52aed4745894.png">




