### PR TITLE
Upgrade stringtemplate to version 4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,11 +61,11 @@ lazy val knockoffDeps = Def.setting { Seq(
   "org.foundweekends" %% "knockoff" % "0.8.6"
 )}
 val unfilteredVersion = "0.9.1"
-val stringtemplateVersion = "3.2.1"
+val stringtemplateVersion = "4.3"
 lazy val libraryDeps = Def.setting { Seq(
   "ws.unfiltered" %% "unfiltered-filter" % unfilteredVersion,
   "ws.unfiltered" %% "unfiltered-jetty" % unfilteredVersion,
-  "org.antlr" % "stringtemplate" % stringtemplateVersion
+  "org.antlr" % "ST4" % stringtemplateVersion
 )}
 val launcherInterfaceVersion = "1.1.2"
 val servletApiVersion = "3.1.0"


### PR DESCRIPTION
- Stringtemplate3 is very outdated (last commit in 2015) and depends on a
  outdated version of antlr. It's causing this issue: 47degrees/sbt-microsites#457

- The `setAttributes` method in stringtemplate3 was always broken,
  as it goes down a different code path compared to `setAttribute` in
  stringtemplate3.

  See [setAttributes](https://github.com/antlr/stringtemplate3/blob/e60b23544539d64d2f57a87e87a5b383cc2b0ba9/src/org/antlr/stringtemplate/StringTemplate.java#L918) and [setAttribute](https://github.com/antlr/stringtemplate3/blob/e60b23544539d64d2f57a87e87a5b383cc2b0ba9/src/org/antlr/stringtemplate/StringTemplate.java#L570) for details,

  Stringtemplate4 removed the `setAttributes` method, so I had to write a
  custom function to handle the '.' characters in the properties.