### PR TITLE
Fix makeSite output dir

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,8 +127,8 @@ lazy val pamflet: Project = (project in file("."))
         }
       ).value
     },
-    TaskKey[Unit]("makeSite") := {
-      val output = target.value / "site"
+    TaskKey[Unit]("makeSite") := Def.uncached {
+      val output = file("target") / "site"
       IO.delete(output)
       val src     = (LocalRootProject / baseDirectory).value / "docs"
       val storage = _root_.pamflet.FileStorage(src, Nil)


### PR DESCRIPTION
`Push to gh-pages` step broken since https://github.com/foundweekends/pamflet/pull/426

> Error: The directory you're trying to deploy named /home/runner/work/pamflet/pamflet/target/site doesn't exist. Please double check the path and any prerequisite build scripts and try again. ❗
Notice: Deployment failed! ❌

https://github.com/foundweekends/pamflet/blob/e29c2efb27dd3d72ebf547becfaa9c05082d5080/.github/workflows/ci.yml#L29